### PR TITLE
Include pdb files in static distribution

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -234,6 +234,10 @@ task cppHeadersZip(type: Zip, dependsOn: make) {
                 include '*.pdb'
                 exclude 'opencv_*.lib'
             }
+            from(sharedBuildDir.resolve("3rdparty").resolve("lib").toFile()) {
+                into project.platformPath + '/static'
+                include '*.pdb'
+            }
         }
     }
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -11,7 +11,7 @@ publishing {
     }
 }
 
-def pubVersion = "${project.ext.version}-17"
+def pubVersion = "${project.ext.version}-18"
 
 def outputsFolder = file("$project.buildDir/outputs")
 
@@ -231,6 +231,7 @@ task cppHeadersZip(type: Zip, dependsOn: make) {
             from(staticBuildDir.resolve("lib").resolve(buildTypeFolder).toFile()) {
                 into project.platformPath + '/static'
                 include 'opencv*.lib'
+                include '*.pdb'
                 exclude 'opencv_*.lib'
             }
         }


### PR DESCRIPTION
We don't need or want to merge the pdb files, as the obj files retain the references to the old names.