### PR TITLE
Disable extraneous data warnings in libjpeg

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -13,7 +13,7 @@ publishing {
     }
 }
 
-def pubVersion = "${project.ext.version}-4"
+def pubVersion = "${project.ext.version}-5"
 
 def outputsFolder = file("$project.buildDir/outputs")
 


### PR DESCRIPTION
These are common with USB cameras.