### PR TITLE
Set WITH_GTK=OFF

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ ext {
             '-DWITH_OPENEXR=OFF',
             '-DWITH_GSTREAMER=OFF',
             '-DWITH_LAPACK=OFF',
-            '-DWITH_GTK=ON',
+            '-DWITH_GTK=OFF',
             '-DWITH_1394=OFF',
             '-DWITH_JASPER=OFF',
             '-DWITH_TIFF=OFF',

--- a/publish.gradle
+++ b/publish.gradle
@@ -13,7 +13,7 @@ publishing {
     }
 }
 
-def pubVersion = "${project.ext.version}-4"
+def pubVersion = "${project.ext.version}-5"
 
 def outputsFolder = file("$project.buildDir/outputs")
 


### PR DESCRIPTION
WITH_GTK=ON causes the Mac build to link to gthreads even though GTK doesn't
exist on that platform.  This creates an artificial dependency on build tools
being installed.