### PR TITLE
Unpin CMake version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,10 +70,6 @@ jobs:
           java-version: 11
           distribution: 'zulu'
           architecture: ${{ matrix.architecture }}
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v1.13
-        with:
-          cmake-version: '3.24.3'
       - run: |
           @call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"
           set PATH=%PATH%;%ANT_HOME%\bin
@@ -96,10 +92,6 @@ jobs:
         with:
           java-version: 11
           distribution: 'zulu'
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v1.13
-        with:
-          cmake-version: '3.24.3'
       - run: ./gradlew build -PjenkinsBuild
         name: Build with Gradle
       - uses: actions/upload-artifact@v3
@@ -118,10 +110,6 @@ jobs:
         with:
           java-version: 11
           distribution: 'zulu'
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v1.13
-        with:
-          cmake-version: '3.24.3'
       - run: ./gradlew build -PjenkinsBuild -Pforcealternatemacbuild
         name: Build with Gradle
       - uses: actions/upload-artifact@v3
@@ -147,10 +135,6 @@ jobs:
         with:
           java-version: 11
           distribution: 'zulu'
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v1.13
-        with:
-          cmake-version: '3.24.3'
       - run: ./gradlew copyToUpload -Prunmerge
         name: Build with Gradle
         if: |


### PR DESCRIPTION
We had to pin CMake in December due to a bug in the cmake version that the windows and macos runners used. 
They've since updated past that so we are fine to unpin it.

Builds fine:
https://github.com/rzblue/thirdparty-opencv/actions/runs/5009494418

reverts #66 