### PR TITLE
Set DependentLoadFlags on shared windows binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: wpilib/roborio-cross-ubuntu:2023-22.04
+          - container: wpilib/roborio-cross-ubuntu:2024-22.04
             artifact-name: Athena
             build-options: "-Pplatform=linux-athena"
           - container: wpilib/raspbian-cross-ubuntu:bullseye-22.04

--- a/arm-frc-gnueabi.toolchain.cmake
+++ b/arm-frc-gnueabi.toolchain.cmake
@@ -1,5 +1,5 @@
 set(GCC_COMPILER_VERSION "" CACHE STRING "GCC Compiler version")
-set(GNU_MACHINE "arm-frc2023-linux-gnueabi" CACHE STRING "GNU compiler triple")
+set(GNU_MACHINE "arm-frc2024-linux-gnueabi" CACHE STRING "GNU compiler triple")
 set(SOFTFP yes)
 set(ARM_LINUX_SYSROOT /usr/local/arm-nilrt-linux-gnueabi/sysroot)
 include("${CMAKE_CURRENT_LIST_DIR}/opencv/platforms/linux/arm.toolchain.cmake")

--- a/build.gradle
+++ b/build.gradle
@@ -183,8 +183,8 @@ def stripExe = 'strip'
 def objCopyExe = 'objcopy'
 
 if (project.platform == "linux-athena") {
-    stripExe = 'arm-frc2023-linux-gnueabi-strip'
-    objCopyExe = 'arm-frc2023-linux-gnueabi-objcopy'
+    stripExe = 'arm-frc2024-linux-gnueabi-strip'
+    objCopyExe = 'arm-frc2024-linux-gnueabi-objcopy'
 } else if (project.platform == "linux-arm32") {
     stripExe = 'armv6-bullseye-linux-gnueabihf-strip'
     objCopyExe = 'armv6-bullseye-linux-gnueabihf-objcopy'

--- a/build.gradle
+++ b/build.gradle
@@ -210,6 +210,10 @@ if (project.platform == "linux-athena") {
             def args = defaultCmakeArgs
             if (buildType.contains("Shared")) {
                 args = args + '-DBUILD_SHARED_LIBS=ON' + '-DOPENCV_DEBUG_POSTFIX=d'
+
+                if (project.platform.contains('windows')) {
+                    args = args + '-DCMAKE_SHARED_LINKER_FLAGS=/DEPENDENTLOADFLAG:0x1100'
+                }
             } else {
                 args = args + '-DBUILD_SHARED_LIBS=OFF'
             }

--- a/publish.gradle
+++ b/publish.gradle
@@ -13,7 +13,7 @@ publishing {
     }
 }
 
-def pubVersion = "${project.ext.version}-2"
+def pubVersion = "${project.ext.version}-3"
 
 def outputsFolder = file("$project.buildDir/outputs")
 


### PR DESCRIPTION
DependentLoadFlags is something added in Windows 10 RS1 that allows modules to specify how they load their dll dependencies.  By default, the application path, system32, and some other paths are searched. However, for our use this is kind of a pain, as when we extract libraries, they're not in the same path as the executable.

This PR adds the LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR flag, which lets us specify to load from our own dll directory first.