### PR TITLE
Add DependentLoadFlags to CMAKE_MODULE_LINKER_FLAGS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,7 +212,7 @@ if (project.platform == "linux-athena") {
                 args = args + '-DBUILD_SHARED_LIBS=ON' + '-DOPENCV_DEBUG_POSTFIX=d'
 
                 if (project.platform.contains('windows')) {
-                    args = args + '-DCMAKE_SHARED_LINKER_FLAGS=/DEPENDENTLOADFLAG:0x1100'
+                    args = args + '-DCMAKE_SHARED_LINKER_FLAGS=/DEPENDENTLOADFLAG:0x1100' + '-DCMAKE_MODULE_LINKER_FLAGS=/DEPENDENTLOADFLAG:0x1100'
                 }
             } else {
                 args = args + '-DBUILD_SHARED_LIBS=OFF'

--- a/publish.gradle
+++ b/publish.gradle
@@ -13,7 +13,7 @@ publishing {
     }
 }
 
-def pubVersion = "${project.ext.version}-3"
+def pubVersion = "${project.ext.version}-4"
 
 def outputsFolder = file("$project.buildDir/outputs")
 


### PR DESCRIPTION
Added to shared libraries, but jni is a module library, so needs to be added there.