### PR TITLE
Enable protobuf support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ ext {
             '-DWITH_WEBP=OFF',
             '-DBUILD_JAVA=ON',
             '-DBUILD_WITH_STATIC_CRT=OFF',
-            '-DWITH_PROTOBUF=OFF',
+            '-DWITH_PROTOBUF=ON',
             '-DWITH_DIRECTX=OFF',
             '-DENABLE_CXX11=ON',
             '-DOPENCV_JAVA_SOURCE_VERSION=1.8',


### PR DESCRIPTION
Submitting on behalf of the photonvision project. 

In order to seamlessly support object detection through OpenCV DNN module we ask that wpilib enable protobuf support. Protobuf support is required to load DNN models in the `.onnx` file format.

While waiting for 2025 versions we ask that a 2024 `v4.8.0-5` could be released with this change in the meantime.

CC @mcm001