### PR TITLE
Add aruco headers.

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -86,6 +86,10 @@ task cppHeadersZip(type: Zip, dependsOn: make) {
         exclude '**/CMakeLists.txt'
     }
 
+    from ('opencv_contrib/modules/aruco') {
+        into '/opencv2/contrib/aruco'
+    }
+
     from (project.cmakeBuildDirectory.resolve('opencv2').toFile()) {
         into '/opencv2/'
     }


### PR DESCRIPTION
WPICal needs access to the aruco library from opencv.