### PR TITLE
Remove unused parts of the OpenCV build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "opencv"]
 	path = opencv
 	url = https://github.com/wpilibsuite/opencv.git
-[submodule "opencv_contrib"]
-	path = opencv_contrib
-	url = https://github.com/opencv/opencv_contrib

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ ext {
             '-DBUILD_PNG=ON',
             '-DBUILD_ZLIB=ON',
             '-DBUILD_TESTS=OFF',
-            '-DPython_ADDITIONAL_VERSIONS=3.5',
             '-DWITH_WEBP=OFF',
             '-DBUILD_JAVA=ON',
             '-DBUILD_WITH_STATIC_CRT=OFF',
@@ -65,7 +64,6 @@ ext {
             '-DBUILD_opencv_apps=OFF',
             '-DBUILD_TESTS=OFF',
             '-DBUILD_PERF_TESTS=OFF',
-            "-DOPENCV_EXTRA_MODULES_PATH=$rootDir/opencv_contrib/modules/aruco",
             '-DCMAKE_INSTALL_PREFIX=install'
     ]
 }
@@ -329,7 +327,7 @@ if (project.platform == "linux-athena") {
                 dependsOn 'make' + buildType
                 workingDir buildDirectory.resolve("lib").resolve(buildTypeFolder).toString()
                 executable 'lib'
-                def inputFiles = ["opencv_calib3d${project.libVersion}", "opencv_features2d${project.libVersion}", "opencv_flann${project.libVersion}", "opencv_gapi${project.libVersion}", "opencv_highgui${project.libVersion}", "opencv_imgcodecs${project.libVersion}", "opencv_imgproc${project.libVersion}", "opencv_ml${project.libVersion}", "opencv_objdetect${project.libVersion}", "opencv_photo${project.libVersion}", "opencv_stitching${project.libVersion}", "opencv_videoio${project.libVersion}", "opencv_video${project.libVersion}", "opencv_core${project.libVersion}", "opencv_aruco${project.libVersion}", "../../3rdparty/lib/${buildTypeFolder}/ade", "../../3rdparty/lib/${buildTypeFolder}/libjpeg-turbo", "../../3rdparty/lib/${buildTypeFolder}/libopenjp2", "../../3rdparty/lib/${buildTypeFolder}/libpng", "../../3rdparty/lib/${buildTypeFolder}/zlib"]
+                def inputFiles = ["opencv_calib3d${project.libVersion}", "opencv_features2d${project.libVersion}", "opencv_flann${project.libVersion}", "opencv_gapi${project.libVersion}", "opencv_highgui${project.libVersion}", "opencv_imgcodecs${project.libVersion}", "opencv_imgproc${project.libVersion}", "opencv_ml${project.libVersion}", "opencv_objdetect${project.libVersion}", "opencv_photo${project.libVersion}", "opencv_stitching${project.libVersion}", "opencv_videoio${project.libVersion}", "opencv_video${project.libVersion}", "opencv_core${project.libVersion}", "../../3rdparty/lib/${buildTypeFolder}/ade", "../../3rdparty/lib/${buildTypeFolder}/libjpeg-turbo", "../../3rdparty/lib/${buildTypeFolder}/libopenjp2", "../../3rdparty/lib/${buildTypeFolder}/libpng", "../../3rdparty/lib/${buildTypeFolder}/zlib"]
                 def setArgs = ["/OUT:opencv${project.libVersion}.lib"]
                 inputFiles.each {
                     def inFile = it
@@ -379,7 +377,7 @@ if (project.platform == "linux-athena") {
                 workingDir buildDirectory.resolve("lib").toString()
                 executable 'ar'
                 args = ['-M']
-                def inputFiles = ["libopencv_calib3d", "libopencv_features2d", "libopencv_flann", "libopencv_gapi", "libopencv_highgui", "libopencv_imgcodecs", "libopencv_imgproc", "libopencv_ml",  "libopencv_objdetect", "libopencv_photo", "libopencv_stitching", "libopencv_videoio", "libopencv_video", "libopencv_core", "libopencv_aruco", "../3rdparty/lib/libade", "../3rdparty/lib/liblibjpeg-turbo", "../3rdparty/lib/liblibopenjp2", "../3rdparty/lib/liblibpng", "../3rdparty/lib/libzlib"]
+                def inputFiles = ["libopencv_calib3d", "libopencv_features2d", "libopencv_flann", "libopencv_gapi", "libopencv_highgui", "libopencv_imgcodecs", "libopencv_imgproc", "libopencv_ml",  "libopencv_objdetect", "libopencv_photo", "libopencv_stitching", "libopencv_videoio", "libopencv_video", "libopencv_core", "../3rdparty/lib/libade", "../3rdparty/lib/liblibjpeg-turbo", "../3rdparty/lib/liblibopenjp2", "../3rdparty/lib/liblibpng", "../3rdparty/lib/libzlib"]
 
                 def inputString = "create libopencv${project.libVersion}.a\n"
                 inputFiles.each {

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,6 @@ import java.nio.file.Paths;
 
 apply plugin: 'java'
 
-def date = new Date()
-def formattedDate = date.format('yyMMdd')
 ext.version = "4.10.0"
 ext.soVersion = "4.10"
 ext.libVersion = "${ext.version.replace(".", "")}"

--- a/publish.gradle
+++ b/publish.gradle
@@ -122,19 +122,6 @@ task cppHeadersZip(type: Zip, dependsOn: make) {
         archiveBaseName = zipBaseName
         duplicatesStrategy = 'exclude'
 
-        manifest {
-            attributes(
-                    "Created-By": "WPILib Gradle Build Script",
-                    "Implementation-Title": "OpenCV Native Libraries, ${project.ext.platformClassifier}",
-                    "Implementation-Version": pubVersion,
-                    "Implementation-Vendor": "Itseez",
-
-                    "Bundle-Name": "${archiveBaseName.get()}",
-                    "Bundle-Version": pubVersion,
-                    "Bundle-License": "https://opensource.org/licenses/BSD-3-Clause",
-                    "Bundle-Vendor": "WPILib")
-        }
-
         from(licenseFile) {
             into '/'
         }
@@ -210,19 +197,6 @@ task cppHeadersZip(type: Zip, dependsOn: make) {
         archiveClassifier = outputClassifierStatic
         archiveBaseName = zipBaseName
         duplicatesStrategy = 'exclude'
-
-        manifest {
-            attributes(
-                    "Created-By": "WPILib Gradle Build Script",
-                    "Implementation-Title": "OpenCV Native Libraries, ${project.ext.platformClassifier}",
-                    "Implementation-Version": pubVersion,
-                    "Implementation-Vendor": "Itseez",
-
-                    "Bundle-Name": "${archiveBaseName.get()}",
-                    "Bundle-Version": pubVersion,
-                    "Bundle-License": "https://opensource.org/licenses/BSD-3-Clause",
-                    "Bundle-Vendor": "WPILib")
-        }
 
         from(licenseFile) {
             into '/'

--- a/publish.gradle
+++ b/publish.gradle
@@ -86,10 +86,6 @@ task cppHeadersZip(type: Zip, dependsOn: make) {
         exclude '**/CMakeLists.txt'
     }
 
-    from ('opencv_contrib/modules/aruco/include') {
-        into '/'
-    }
-
     from (project.cmakeBuildDirectory.resolve('opencv2').toFile()) {
         into '/opencv2/'
     }


### PR DESCRIPTION
Aruco module has been replaced by objdetect, unused date variables were removed, and manifest blocks that didn't do anything were removed from zip tasks.