### PR TITLE
Use mold for zstd compressed debug info and extra space saving flags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'true'
+      - uses: rui314/setup-mold@v1
+        with:
+          make-default: true
       - run: sudo apt-get update && sudo apt-get install ant -y && sudo rm -rf /var/lib/apt/lists/* && sudo rm -f /bin/ant && sudo ln -s /usr/share/ant/bin/ant /bin/ant
         name: Install Ant
       - run: ./gradlew build -PjenkinsBuild ${{ matrix.build-options }}

--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,7 @@ if (project.platform == "linux-arm64") {
             } else if (project.platform == "linux-arm64") {
                 return args + '-DOPENCV_EXTRA_FLAGS_DEBUG=-Og' + "-DCMAKE_MODULE_PATH=$rootDir/arm-frc-modules"
             } else if (project.platform == "linux-x86_64") {
-                return args + "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--compress-debug-sections=zstd:18 -Wl,--pack-dyn-relocs=relr -Wl,--icf=all"
+                return args + "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--compress-debug-sections=zstd:19 -Wl,--pack-dyn-relocs=relr -Wl,--icf=all"
             } else if (project.platform == "osx-arm64") {
                 return args + "-DCMAKE_OSX_ARCHITECTURES=arm64" + "-DCMAKE_OSX_DEPLOYMENT_TARGET:String=13.0" + "-DCMAKE_BUILD_RPATH=@loader_path"
             } else if (project.platform == "osx-x86_64") {

--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,7 @@ if (project.platform == "linux-arm64") {
             } else if (project.platform == "linux-arm64") {
                 return args + '-DOPENCV_EXTRA_FLAGS_DEBUG=-Og' + "-DCMAKE_MODULE_PATH=$rootDir/arm-frc-modules"
             } else if (project.platform == "linux-x86_64") {
-                return args + '-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--compress-debug-sections=zstd:18'
+                return args + "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--compress-debug-sections=zstd:18 -Wl,--pack-dyn-relocs=relr -Wl,--icf=all"
             } else if (project.platform == "osx-arm64") {
                 return args + "-DCMAKE_OSX_ARCHITECTURES=arm64" + "-DCMAKE_OSX_DEPLOYMENT_TARGET:String=13.0" + "-DCMAKE_BUILD_RPATH=@loader_path"
             } else if (project.platform == "osx-x86_64") {

--- a/build.gradle
+++ b/build.gradle
@@ -220,6 +220,8 @@ if (project.platform == "linux-arm64") {
                 return args + '-DOPENCV_EXTRA_FLAGS_DEBUG=-Og' + "-DCMAKE_MODULE_PATH=$rootDir/arm-frc-modules"
             } else if (project.platform == "linux-arm64") {
                 return args + '-DOPENCV_EXTRA_FLAGS_DEBUG=-Og' + "-DCMAKE_MODULE_PATH=$rootDir/arm-frc-modules"
+            } else if (project.platform == "linux-x86_64") {
+                return args + '-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--compress-debug-sections=zstd:18'
             } else if (project.platform == "osx-arm64") {
                 return args + "-DCMAKE_OSX_ARCHITECTURES=arm64" + "-DCMAKE_OSX_DEPLOYMENT_TARGET:String=13.0" + "-DCMAKE_BUILD_RPATH=@loader_path"
             } else if (project.platform == "osx-x86_64") {


### PR DESCRIPTION
zstd takes the uploaded artifact size down by ~14 MB, --pack-dyn-relocs=relr and --icf=all take it down another ~6.